### PR TITLE
Upgraded NuGet packages

### DIFF
--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.APISite/TownSuite.ConversionServer.APISite.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.APISite/TownSuite.ConversionServer.APISite.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
     <PackageReference Include="ZNetCS.AspNetCore.Authentication.Basic" Version="6.0.1" />
   </ItemGroup>
 

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.APISite/TownSuite.ConversionServer.APISite.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.APISite/TownSuite.ConversionServer.APISite.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="ZNetCS.AspNetCore.Authentication.Basic" Version="6.0.1" />
   </ItemGroup>
 

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.StandardServices/TownSuite.ConversionServer.StandardServices.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.StandardServices/TownSuite.ConversionServer.StandardServices.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Tests.GeneralTests/TownSuite.ConversionServer.Tests.GeneralTests.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Tests.GeneralTests/TownSuite.ConversionServer.Tests.GeneralTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
 

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Tests.GeneralTests/Utilities/GhostScript/PdfToImageConverterTests.cs
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Tests.GeneralTests/Utilities/GhostScript/PdfToImageConverterTests.cs
@@ -27,7 +27,7 @@ namespace TownSuite.ConversionServer.Tests.GeneralTests.Utilities.GhostScript
         public async Task ConvertTest()
         {
             var singlePage = System.IO.Path.Combine(GetAssetsDirectory(), "single_page_test.pdf");
-            Assert.IsTrue(System.IO.File.Exists(singlePage));
+            Assert.That(System.IO.File.Exists(singlePage), Is.True);
             var pageBytes = await System.IO.File.ReadAllBytesAsync(singlePage);
 
             var res = await _converter.Convert(pageBytes);
@@ -35,10 +35,10 @@ namespace TownSuite.ConversionServer.Tests.GeneralTests.Utilities.GhostScript
             int resCount = 0;
             foreach (var image in res)
             {
-                Assert.Greater(image.Length, 0);
+                Assert.That(image.Length, Is.GreaterThan(0));
                 resCount++;
             }
-            Assert.AreEqual(1, resCount);
+            Assert.That(resCount, Is.EqualTo(1));
             
         }
 
@@ -46,7 +46,7 @@ namespace TownSuite.ConversionServer.Tests.GeneralTests.Utilities.GhostScript
         public async Task ConvertMultiPageTest()
         {
             var multiPage = System.IO.Path.Combine(GetAssetsDirectory(), "multi_page_pdf.pdf");
-            Assert.IsTrue(System.IO.File.Exists(multiPage));
+            Assert.That(System.IO.File.Exists(multiPage), Is.True);
             var pageBytes = await System.IO.File.ReadAllBytesAsync(multiPage);
 
             var res = await _converter.Convert(pageBytes);
@@ -54,10 +54,10 @@ namespace TownSuite.ConversionServer.Tests.GeneralTests.Utilities.GhostScript
             int resCount = 0;
             foreach (var image in res)
             {
-                Assert.Greater(image.Length, 0, "Image cannot be zero bytes");
+                Assert.That(image.Length, Is.GreaterThan(0), "Image cannot be zero bytes");
                 resCount++;
             }
-            Assert.Greater(resCount, 1, "Multipage test requires png file count greater than 1.");
+            Assert.That(resCount, Is.GreaterThan(1), "Multipage test requires png file count greater than 1.");
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace TownSuite.ConversionServer.Tests.GeneralTests.Utilities.GhostScript
         {
             string exeLocation = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             var dir = System.IO.Path.Combine(exeLocation, "Utilities", "GhostScript", "Assets");
-            Assert.IsTrue(System.IO.Directory.Exists(dir), "Testing assets directory missing. Ensure in same directory as executable.");
+            Assert.That(System.IO.Directory.Exists(dir), Is.True, "Testing assets directory missing. Ensure in same directory as executable.");
             return dir;
         }
     }

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.GhostScript/TownSuite.ConversionServer.Utilities.GhostScript.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.GhostScript/TownSuite.ConversionServer.Utilities.GhostScript.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.Newtonsoft/TownSuite.ConversionServer.Utilities.Newtonsoft.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.Newtonsoft/TownSuite.ConversionServer.Utilities.Newtonsoft.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.REPL/TownSuite.ConversionServer.Utilities.REPL.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.REPL/TownSuite.ConversionServer.Utilities.REPL.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.REPL/TownSuite.ConversionServer.Utilities.REPL.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.REPL/TownSuite.ConversionServer.Utilities.REPL.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TownSuite.ConversionServer.Common.Models\TownSuite.ConversionServer.Common.Models.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.TownSuiteLogging/TownSuite.ConversionServer.Utilities.TownSuiteLogging.csproj
+++ b/TownSuite.ConversionServer/TownSuite.ConversionServer.Utilities.TownSuiteLogging/TownSuite.ConversionServer.Utilities.TownSuiteLogging.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Upgraded NuGet packages as recommended by dependabot. Any errors or warnings introduced were fixed. The solution does not contain any warnings after these changes.

The command line REPL can now be used to make a call to the /PdfConverter end point, which works with byte[] to handle the conversion. The REPL helps with testing it. Both the Stream and byte[] conversion end points were tested with multiple PDF files.

Currently, 3 tests in the pipeline are expected to fail due to GhostScript not downloaded. This is not due to changes in this PR. The tests do pass when GhostScript is available.

## Motivation / Context
The following pull requests were created by dependabot. This PR covers those pull requests:
https://github.com/TownSuite/TownSuite.ConversionServer/pull/24
https://github.com/TownSuite/TownSuite.ConversionServer/pull/31
https://github.com/TownSuite/TownSuite.ConversionServer/pull/32
https://github.com/TownSuite/TownSuite.ConversionServer/pull/33
https://github.com/TownSuite/TownSuite.ConversionServer/pull/34
https://github.com/TownSuite/TownSuite.ConversionServer/pull/36