### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.ConversionServer/security/code-scanning/3](https://github.com/TownSuite/TownSuite.ConversionServer/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal necessary scopes to the `GITHUB_TOKEN`. For this workflow, the steps only read repository contents (via `actions/checkout`) and run local `dotnet` commands; they do not need to write to the repository or to GitHub resources. Therefore, `contents: read` at the workflow or job level is sufficient.

The best fix without changing functionality is to add a root-level `permissions` block after the `on:` section, applying to all jobs that do not override it. In `.github/workflows/dotnet.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block (lines 3–7) and the `jobs:` block (line 9). No imports or other code changes are needed because this is purely a GitHub Actions configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
